### PR TITLE
fix: Add OVERWRITE to SurrealDB schema definitions

### DIFF
--- a/src/storage/vector-db.ts
+++ b/src/storage/vector-db.ts
@@ -86,15 +86,16 @@ export class SemanticVectorDB {
       });
 
       // Define the code documents table with full-text search capabilities
+      // Use OVERWRITE to handle re-initialization gracefully
       await this.db.query(`
-        DEFINE ANALYZER code_analyzer TOKENIZERS blank FILTERS lowercase,ascii;
-        DEFINE TABLE code_documents SCHEMAFULL;
-        DEFINE FIELD code ON code_documents TYPE string;
-        DEFINE FIELD embedding ON code_documents TYPE array;
-        DEFINE FIELD metadata ON code_documents TYPE object;
-        DEFINE FIELD created ON code_documents TYPE datetime DEFAULT time::now();
-        DEFINE FIELD updated ON code_documents TYPE datetime DEFAULT time::now();
-        DEFINE INDEX code_content ON code_documents COLUMNS code SEARCH ANALYZER code_analyzer BM25(1.2,0.75) HIGHLIGHTS;
+        DEFINE ANALYZER OVERWRITE code_analyzer TOKENIZERS blank FILTERS lowercase,ascii;
+        DEFINE TABLE OVERWRITE code_documents SCHEMAFULL;
+        DEFINE FIELD OVERWRITE code ON code_documents TYPE string;
+        DEFINE FIELD OVERWRITE embedding ON code_documents TYPE array;
+        DEFINE FIELD OVERWRITE metadata ON code_documents TYPE object;
+        DEFINE FIELD OVERWRITE created ON code_documents TYPE datetime DEFAULT time::now();
+        DEFINE FIELD OVERWRITE updated ON code_documents TYPE datetime DEFAULT time::now();
+        DEFINE INDEX OVERWRITE code_content ON code_documents COLUMNS code SEARCH ANALYZER code_analyzer BM25(1.2,0.75) HIGHLIGHTS;
       `);
 
       this.initialized = true;


### PR DESCRIPTION
## Summary
SurrealDB DEFINE statements fail with "already exists" errors on subsequent runs. This caused `in-memoria learn` to return 0 concepts after the first successful run.

## Problem
In `src/storage/vector-db.ts`, the schema initialization uses:
```sql
DEFINE ANALYZER code_analyzer ...
DEFINE TABLE code_documents ...
```

On the second run, SurrealDB throws:
```
ResponseError: The analyzer 'code_analyzer' already exists
```

This error bubbles up and causes the entire learn process to fail silently, returning 0 concepts.

## Fix
Added `OVERWRITE` keyword to all DEFINE statements:
```sql
DEFINE ANALYZER OVERWRITE code_analyzer ...
DEFINE TABLE OVERWRITE code_documents ...
```

Per [SurrealDB documentation](https://surrealdb.com/docs/surrealql/statements/define/table), OVERWRITE updates schema definitions without deleting existing data.

## Testing
- First run: 1522 concepts learned ✅
- Second run: 1522 concepts learned ✅ (previously returned 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)